### PR TITLE
Set position of each element when unmarshalling

### DIFF
--- a/block.go
+++ b/block.go
@@ -44,7 +44,6 @@ const (
 
 // Block represents EBML Block/SimpleBlock element
 type Block struct {
-	Metadata
 	TrackNumber uint64
 	Timecode    int16
 	Keyframe    bool

--- a/block_test.go
+++ b/block_test.go
@@ -27,15 +27,15 @@ func TestUnmarshalBlock(t *testing.T) {
 	}{
 		"Track1BKeyframeInvisible": {
 			[]byte{0x82, 0x01, 0x23, 0x88, 0xAA, 0xCC},
-			Block{Metadata{}, 0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
+			Block{0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
 		},
 		"Track2BDiscardable": {
 			[]byte{0x42, 0x13, 0x01, 0x23, 0x01, 0x11, 0x22, 0x33},
-			Block{Metadata{}, 0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
+			Block{0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
 		},
 		"Track3BNoData": {
 			[]byte{0x21, 0x23, 0x45, 0x00, 0x02, 0x00},
-			Block{Metadata{}, 0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
+			Block{0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
 		},
 	}
 	for n, c := range testCases {
@@ -57,15 +57,15 @@ func TestMarshalBlock(t *testing.T) {
 		expected []byte
 	}{
 		"Track1BKeyframeInvisible": {
-			Block{Metadata{}, 0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
+			Block{0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
 			[]byte{0x82, 0x01, 0x23, 0x88, 0xAA, 0xCC},
 		},
 		"Track2BDiscardable": {
-			Block{Metadata{}, 0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
+			Block{0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
 			[]byte{0x42, 0x13, 0x01, 0x23, 0x01, 0x11, 0x22, 0x33},
 		},
 		"Track3BNoData": {
-			Block{Metadata{}, 0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
+			Block{0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
 			[]byte{0x21, 0x23, 0x45, 0x00, 0x02, 0x00},
 		},
 	}

--- a/block_test.go
+++ b/block_test.go
@@ -27,22 +27,25 @@ func TestUnmarshalBlock(t *testing.T) {
 	}{
 		"Track1BKeyframeInvisible": {
 			[]byte{0x82, 0x01, 0x23, 0x88, 0xAA, 0xCC},
-			Block{0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
+			Block{Metadata{}, 0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
 		},
 		"Track2BDiscardable": {
 			[]byte{0x42, 0x13, 0x01, 0x23, 0x01, 0x11, 0x22, 0x33},
-			Block{0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
+			Block{Metadata{}, 0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
 		},
 		"Track3BNoData": {
 			[]byte{0x21, 0x23, 0x45, 0x00, 0x02, 0x00},
-			Block{0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
+			Block{Metadata{}, 0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
 		},
 	}
 	for n, c := range testCases {
 		t.Run(n, func(t *testing.T) {
-			block, err := UnmarshalBlock(bytes.NewBuffer(c.input))
+			block, br, err := UnmarshalBlock(bytes.NewBuffer(c.input))
 			if err != nil {
 				t.Fatalf("Failed to unmarshal block: %v", err)
+			}
+			if br != len(c.input) {
+				t.Errorf("Unexpected number of read bytes, expected: %v, got: %v", len(c.input), br)
 			}
 			if !reflect.DeepEqual(c.expected, *block) {
 				t.Errorf("Unexpected unmarshal result, expected: %v, got: %v", c.expected, *block)
@@ -57,15 +60,15 @@ func TestMarshalBlock(t *testing.T) {
 		expected []byte
 	}{
 		"Track1BKeyframeInvisible": {
-			Block{0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
+			Block{Metadata{}, 0x02, 0x0123, true, true, LacingNo, false, nil, [][]byte{[]byte{0xAA, 0xCC}}},
 			[]byte{0x82, 0x01, 0x23, 0x88, 0xAA, 0xCC},
 		},
 		"Track2BDiscardable": {
-			Block{0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
+			Block{Metadata{}, 0x0213, 0x0123, false, false, LacingNo, true, nil, [][]byte{[]byte{0x11, 0x22, 0x33}}},
 			[]byte{0x42, 0x13, 0x01, 0x23, 0x01, 0x11, 0x22, 0x33},
 		},
 		"Track3BNoData": {
-			Block{0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
+			Block{Metadata{}, 0x012345, 0x0002, false, false, LacingNo, false, nil, [][]byte{[]byte{}}},
 			[]byte{0x21, 0x23, 0x45, 0x00, 0x02, 0x00},
 		},
 	}

--- a/block_test.go
+++ b/block_test.go
@@ -40,12 +40,9 @@ func TestUnmarshalBlock(t *testing.T) {
 	}
 	for n, c := range testCases {
 		t.Run(n, func(t *testing.T) {
-			block, br, err := UnmarshalBlock(bytes.NewBuffer(c.input))
+			block, err := UnmarshalBlock(bytes.NewBuffer(c.input))
 			if err != nil {
 				t.Fatalf("Failed to unmarshal block: %v", err)
-			}
-			if br != len(c.input) {
-				t.Errorf("Unexpected number of read bytes, expected: %v, got: %v", len(c.input), br)
 			}
 			if !reflect.DeepEqual(c.expected, *block) {
 				t.Errorf("Unexpected unmarshal result, expected: %v, got: %v", c.expected, *block)

--- a/datatype.go
+++ b/datatype.go
@@ -51,3 +51,8 @@ func (t Type) String() string {
 		return "Unknown type"
 	}
 }
+
+// Metadata represents a metadata (position) of the EBML element
+type Metadata struct {
+	Position uint64
+}

--- a/elementtable.go
+++ b/elementtable.go
@@ -91,7 +91,7 @@ func init() {
 	revTable = make(elementRevTable)
 
 	for k, v := range table {
-		e, err := readVInt(bytes.NewBuffer(v.b))
+		e, _, err := readVInt(bytes.NewBuffer(v.b))
 		if err != nil {
 			panic(err)
 		}

--- a/marshal_roundtrip_test.go
+++ b/marshal_roundtrip_test.go
@@ -30,7 +30,6 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 		Segment webm.Segment    `ebml:"Segment,inf"`
 	}{
 		Header: webm.EBMLHeader{
-			Metadata:           ebml.Metadata{Position: 0},
 			EBMLVersion:        1,
 			EBMLReadVersion:    1,
 			EBMLMaxIDLength:    4,

--- a/marshal_roundtrip_test.go
+++ b/marshal_roundtrip_test.go
@@ -30,6 +30,7 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 		Segment webm.Segment    `ebml:"Segment,inf"`
 	}{
 		Header: webm.EBMLHeader{
+			Metadata:           ebml.Metadata{Position: 0},
 			EBMLVersion:        1,
 			EBMLReadVersion:    1,
 			EBMLMaxIDLength:    4,
@@ -39,15 +40,19 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 			DocTypeReadVersion: 2,
 		},
 		Segment: webm.Segment{
+			Metadata: ebml.Metadata{Position: 37},
 			Info: webm.Info{
+				Metadata:      ebml.Metadata{Position: 49},
 				TimecodeScale: 1000000, // 1ms
 				MuxingApp:     "ebml-go example",
 				WritingApp:    "ebml-go example",
 				DateUTC:       time.Now().Truncate(time.Millisecond),
 			},
 			Tracks: webm.Tracks{
+				Metadata: ebml.Metadata{Position: 110},
 				TrackEntry: []webm.TrackEntry{
 					{
+						Metadata:        ebml.Metadata{Position: 115},
 						Name:            "Video",
 						TrackNumber:     1,
 						TrackUID:        12345,
@@ -55,12 +60,14 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 						TrackType:       1,
 						DefaultDuration: 33333333,
 						Video: &webm.Video{
+							Metadata:    ebml.Metadata{Position: 158},
 							PixelWidth:  320,
 							PixelHeight: 240,
 						},
 						CodecPrivate: []byte{0x01, 0x02},
 					},
 					{
+						Metadata:        ebml.Metadata{Position: 167},
 						Name:            "Audio",
 						TrackNumber:     2,
 						TrackUID:        54321,
@@ -68,6 +75,7 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 						TrackType:       2,
 						DefaultDuration: 33333333,
 						Audio: &webm.Audio{
+							Metadata:          ebml.Metadata{Position: 206},
 							SamplingFrequency: 48000.0,
 							Channels:          2,
 						},
@@ -76,18 +84,26 @@ func TestMarshal_RoundtripWebM(t *testing.T) {
 			},
 			Cluster: []webm.Cluster{
 				{
+					Metadata: ebml.Metadata{Position: 221},
 					Timecode: 0,
 				},
 				{
+					Metadata: ebml.Metadata{Position: 229},
 					Timecode: 1234567,
 				},
 			},
 			Cues: &webm.Cues{
+				Metadata: ebml.Metadata{Position: 239},
 				CuePoint: []webm.CuePoint{
 					{
-						CueTime: 1,
+						Metadata: ebml.Metadata{Position: 244},
+						CueTime:  1,
 						CueTrackPositions: []webm.CueTrackPosition{
-							{CueTrack: 2, CueClusterPosition: 3},
+							{
+								Metadata:           ebml.Metadata{Position: 249},
+								CueTrack:           2,
+								CueClusterPosition: 3,
+							},
 						},
 					},
 				},

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -66,10 +66,6 @@ func readElement(r0 io.Reader, n int64, vo reflect.Value, currentPos, elementPos
 	var metadataField *field
 	if vo.IsValid() {
 		for i := 0; i < vo.NumField(); i++ {
-			if vo.Type().Field(i).Name == "Metadata" {
-				println("aaa")
-			}
-
 			var nn []string
 			if n, ok := vo.Type().Field(i).Tag.Lookup("ebml"); ok {
 				nn = strings.Split(n, ",")

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -129,8 +129,8 @@ func readElement(r0 io.Reader, n int64, vo reflect.Value, pos uint64) (io.Reader
 				r = io.MultiReader(r0, r)
 			}
 		default:
-			val, nb, err := perTypeReader[v.t](r, size)
-			bytesRead += uint64(nb)
+			val, err := perTypeReader[v.t](r, size)
+			bytesRead += size
 			if err != nil {
 				return nil, bytesRead, err
 			}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -16,14 +16,11 @@ package ebml
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"testing"
 )
 
 func ExampleUnmarshal() {
-	b := encodeDataSize(0x10)
-	println(hex.EncodeToString(b))
 	TestBinary := []byte{
 		0x1a, 0x45, 0xdf, 0xa3, // EBML
 		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, // 0x10

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -32,14 +32,24 @@ func ExampleUnmarshal() {
 	}
 	type TestEBML struct {
 		Header struct {
-			Metadata
 			DocType            string `ebml:"EBMLDocType"`
 			DocTypeVersion     uint64 `ebml:"EBMLDocTypeVersion"`
 			DocTypeReadVersion uint64 `ebml:"EBMLDocTypeReadVersion"`
 		} `ebml:"EBML"`
 		Segment struct {
-			Metadata
 			TimecodeScale uint64 `ebml:"TimecodeScale"`
+		} `ebml:"Segment"`
+	}
+	type TestEBMLWithMetadata struct {
+		Header struct {
+			Metadata           Metadata `ebml:"-"`
+			DocType            string   `ebml:"EBMLDocType"`
+			DocTypeVersion     uint64   `ebml:"EBMLDocTypeVersion"`
+			DocTypeReadVersion uint64   `ebml:"EBMLDocTypeReadVersion"`
+		} `ebml:"EBML"`
+		Segment struct {
+			Metadata      Metadata `ebml:"-"`
+			TimecodeScale uint64   `ebml:"TimecodeScale"`
 		} `ebml:"Segment"`
 	}
 
@@ -51,7 +61,17 @@ func ExampleUnmarshal() {
 	}
 	fmt.Println(ret)
 
-	// Output: {{{0} webm 2 2} {{28} 3}}
+	r = bytes.NewReader(TestBinary)
+
+	var ret2 TestEBMLWithMetadata
+	if err := Unmarshal(r, &ret2); err != nil {
+		fmt.Printf("error: %+v\n", err)
+	}
+	fmt.Println(ret2)
+
+	// Output:
+	// {{webm 2 2} {3}}
+	// {{{0} webm 2 2} {{28} 3}}
 }
 
 func TestUnmarshal_Tag(t *testing.T) {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -16,23 +16,34 @@ package ebml
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"testing"
 )
 
 func ExampleUnmarshal() {
+	b := encodeDataSize(0x10)
+	println(hex.EncodeToString(b))
 	TestBinary := []byte{
 		0x1a, 0x45, 0xdf, 0xa3, // EBML
 		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, // 0x10
-		0x42, 0x82, 0x85, 0x77, 0x65, 0x62, 0x6d, 0x00,
-		0x42, 0x87, 0x81, 0x02, 0x42, 0x85, 0x81, 0x02,
+		0x42, 0x82, 0x85, 0x77, 0x65, 0x62, 0x6d, 0x00, // EBMLDocType
+		0x42, 0x87, 0x81, 0x02, // EBMLDocTypeVersion
+		0x42, 0x85, 0x81, 0x02, // EBMLDocTypeReadVersion
+		0x18, 0x53, 0x80, 0x67, 0x85, // Segment
+		0x2a, 0xd7, 0xb1, 0x81, 0x03, // TimecodeScale
 	}
 	type TestEBML struct {
 		Header struct {
+			Metadata
 			DocType            string `ebml:"EBMLDocType"`
 			DocTypeVersion     uint64 `ebml:"EBMLDocTypeVersion"`
 			DocTypeReadVersion uint64 `ebml:"EBMLDocTypeReadVersion"`
 		} `ebml:"EBML"`
+		Segment struct {
+			Metadata
+			TimecodeScale uint64 `ebml:"TimecodeScale"`
+		} `ebml:"Segment"`
 	}
 
 	r := bytes.NewReader(TestBinary)
@@ -43,7 +54,7 @@ func ExampleUnmarshal() {
 	}
 	fmt.Println(ret)
 
-	// Output: {{webm 2 2}}
+	// Output: {{{0} webm 2 2} {{28} 3}}
 }
 
 func TestUnmarshal_Tag(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -32,9 +32,12 @@ func TestDataSize(t *testing.T) {
 
 	for n, c := range testCases {
 		t.Run("Decode "+n, func(t *testing.T) {
-			r, err := readVInt(bytes.NewBuffer(c.b))
+			r, br, err := readVInt(bytes.NewBuffer(c.b))
 			if err != nil {
 				t.Fatalf("Failed to readVInt: %v", err)
+			}
+			if br != len(c.b) {
+				t.Errorf("Unexpected number of read bytes, expected: %d, got: %d", len(c.b), br)
 			}
 			if r != c.i {
 				t.Errorf("Unexpected readVInt result, expected: %d, got: %d", c.i, r)
@@ -73,9 +76,12 @@ func TestElementID(t *testing.T) {
 
 	for n, c := range testCases {
 		t.Run("Decode "+n, func(t *testing.T) {
-			r, err := readVInt(bytes.NewBuffer(c.b))
+			r, br, err := readVInt(bytes.NewBuffer(c.b))
 			if err != nil {
 				t.Fatalf("Failed to readVInt: %v", err)
+			}
+			if br != len(c.b) {
+				t.Errorf("Unexpected number of read bytes, expected: %d, got: %d", len(c.b), br)
 			}
 			if r != c.i {
 				t.Errorf("Unexpected readVInt result, expected: %d, got: %d", c.i, r)
@@ -121,14 +127,17 @@ func TestValue(t *testing.T) {
 		"Float32": {[]byte{0x40, 0x10, 0x00, 0x00}, TypeFloat, float64(2.25), float32(2.25)},
 		"Float64": {[]byte{0x40, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, TypeFloat, float64(2.25), nil},
 		"Block": {[]byte{0x85, 0x12, 0x34, 0x80, 0x34, 0x56}, TypeBlock,
-			Block{uint64(5), int16(0x1234), true, false, LacingNo, false, nil, [][]byte{[]byte{0x34, 0x56}}}, nil,
+			Block{Metadata{}, uint64(5), int16(0x1234), true, false, LacingNo, false, nil, [][]byte{{0x34, 0x56}}}, nil,
 		},
 	}
 	for n, c := range testCases {
 		t.Run("Read "+n, func(t *testing.T) {
-			v, err := perTypeReader[c.t](bytes.NewBuffer(c.b), uint64(len(c.b)))
+			v, br, err := perTypeReader[c.t](bytes.NewBuffer(c.b), uint64(len(c.b)))
 			if err != nil {
 				t.Fatalf("Failed to read%s: %v", n, err)
+			}
+			if br != len(c.b) {
+				t.Errorf("Unexpected number of read bytes, expected: %d, got: %d", len(c.b), br)
 			}
 			if !reflect.DeepEqual(v, c.v) {
 				t.Errorf("Unexpected read%s result, expected: %v, got: %v", n, c.v, v)

--- a/value_test.go
+++ b/value_test.go
@@ -132,12 +132,9 @@ func TestValue(t *testing.T) {
 	}
 	for n, c := range testCases {
 		t.Run("Read "+n, func(t *testing.T) {
-			v, br, err := perTypeReader[c.t](bytes.NewBuffer(c.b), uint64(len(c.b)))
+			v, err := perTypeReader[c.t](bytes.NewBuffer(c.b), uint64(len(c.b)))
 			if err != nil {
 				t.Fatalf("Failed to read%s: %v", n, err)
-			}
-			if br != len(c.b) {
-				t.Errorf("Unexpected number of read bytes, expected: %d, got: %d", len(c.b), br)
 			}
 			if !reflect.DeepEqual(v, c.v) {
 				t.Errorf("Unexpected read%s result, expected: %v, got: %v", n, c.v, v)

--- a/value_test.go
+++ b/value_test.go
@@ -127,7 +127,7 @@ func TestValue(t *testing.T) {
 		"Float32": {[]byte{0x40, 0x10, 0x00, 0x00}, TypeFloat, float64(2.25), float32(2.25)},
 		"Float64": {[]byte{0x40, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, TypeFloat, float64(2.25), nil},
 		"Block": {[]byte{0x85, 0x12, 0x34, 0x80, 0x34, 0x56}, TypeBlock,
-			Block{Metadata{}, uint64(5), int16(0x1234), true, false, LacingNo, false, nil, [][]byte{{0x34, 0x56}}}, nil,
+			Block{uint64(5), int16(0x1234), true, false, LacingNo, false, nil, [][]byte{{0x34, 0x56}}}, nil,
 		},
 	}
 	for n, c := range testCases {

--- a/webm/webm.go
+++ b/webm/webm.go
@@ -22,7 +22,6 @@ import (
 
 // EBMLHeader represents EBML header struct
 type EBMLHeader struct {
-	ebml.Metadata
 	EBMLVersion        uint64 `ebml:"EBMLVersion"`
 	EBMLReadVersion    uint64 `ebml:"EBMLReadVersion"`
 	EBMLMaxIDLength    uint64 `ebml:"EBMLMaxIDLength"`

--- a/webm/webm.go
+++ b/webm/webm.go
@@ -22,6 +22,7 @@ import (
 
 // EBMLHeader represents EBML header struct
 type EBMLHeader struct {
+	ebml.Metadata
 	EBMLVersion        uint64 `ebml:"EBMLVersion"`
 	EBMLReadVersion    uint64 `ebml:"EBMLReadVersion"`
 	EBMLMaxIDLength    uint64 `ebml:"EBMLMaxIDLength"`
@@ -33,7 +34,9 @@ type EBMLHeader struct {
 
 // SeekHead represents SeekHead element struct
 type SeekHead struct {
+	ebml.Metadata
 	Seek []struct {
+		ebml.Metadata
 		SeekID       []byte `ebml:"SeekID"`
 		SeekPosition uint64 `ebml:"SeekPosition"`
 	} `ebml:"Seek"`
@@ -41,6 +44,7 @@ type SeekHead struct {
 
 // Info represents Info element struct
 type Info struct {
+	ebml.Metadata
 	TimecodeScale uint64    `ebml:"TimecodeScale"`
 	MuxingApp     string    `ebml:"MuxingApp,omitempty"`
 	WritingApp    string    `ebml:"WritingApp,omitempty"`
@@ -50,6 +54,7 @@ type Info struct {
 
 // TrackEntry represents TrackEntry element struct
 type TrackEntry struct {
+	ebml.Metadata
 	Name            string `ebml:"Name,omitempty"`
 	TrackNumber     uint64 `ebml:"TrackNumber"`
 	TrackUID        uint64 `ebml:"TrackUID"`
@@ -65,26 +70,31 @@ type TrackEntry struct {
 
 // Audio represents Audio element struct
 type Audio struct {
+	ebml.Metadata
 	SamplingFrequency float64 `ebml:"SamplingFrequency"`
 	Channels          uint64  `ebml:"Channels"`
 }
 
 // Video represents Video element struct
 type Video struct {
+	ebml.Metadata
 	PixelWidth  uint64 `ebml:"PixelWidth"`
 	PixelHeight uint64 `ebml:"PixelHeight"`
 }
 
 // Tracks represents Tracks element struct
 type Tracks struct {
+	ebml.Metadata
 	TrackEntry []TrackEntry `ebml:"TrackEntry"`
 }
 
 // Cluster represents Cluster element struct
 type Cluster struct {
+	ebml.Metadata
 	Timecode   uint64 `ebml:"Timecode"`
 	PrevSize   uint64 `ebml:"PrevSize,omitempty"`
 	BlockGroup []struct {
+		ebml.Metadata
 		BlockDuration uint64       `ebml:"BlockDuration"`
 		Block         []ebml.Block `ebml:"Block"`
 	} `ebml:"BlockGroup"`
@@ -92,21 +102,25 @@ type Cluster struct {
 }
 
 type Cues struct {
+	ebml.Metadata
 	CuePoint []CuePoint `ebml:"CuePoint"`
 }
 
 type CuePoint struct {
+	ebml.Metadata
 	CueTime           uint64             `ebml:"CueTime"`
 	CueTrackPositions []CueTrackPosition `ebml:"CueTrackPositions"`
 }
 
 type CueTrackPosition struct {
+	ebml.Metadata
 	CueTrack           uint64 `ebml:"CueTrack"`
 	CueClusterPosition uint64 `ebml:"CueClusterPosition"`
 }
 
 // Segment represents Segment element struct
 type Segment struct {
+	ebml.Metadata
 	SeekHead *SeekHead `ebml:"SeekHead"`
 	Info     Info      `ebml:"Info"`
 	Tracks   Tracks    `ebml:"Tracks"`
@@ -116,6 +130,7 @@ type Segment struct {
 
 // SegmentStream represents Segment element struct for streaming
 type SegmentStream struct {
+	ebml.Metadata
 	SeekHead *SeekHead `ebml:"SeekHead"`
 	Info     Info      `ebml:"Info"`
 	Tracks   Tracks    `ebml:"Tracks"`

--- a/webm/webm.go
+++ b/webm/webm.go
@@ -33,8 +33,8 @@ type EBMLHeader struct {
 
 // SeekHead represents SeekHead element struct
 type SeekHead struct {
-	ebml.Metadata
-	Seek []struct {
+	Metadata ebml.Metadata `ebml:"-"`
+	Seek     []struct {
 		ebml.Metadata
 		SeekID       []byte `ebml:"SeekID"`
 		SeekPosition uint64 `ebml:"SeekPosition"`
@@ -43,55 +43,55 @@ type SeekHead struct {
 
 // Info represents Info element struct
 type Info struct {
-	ebml.Metadata
-	TimecodeScale uint64    `ebml:"TimecodeScale"`
-	MuxingApp     string    `ebml:"MuxingApp,omitempty"`
-	WritingApp    string    `ebml:"WritingApp,omitempty"`
-	Duration      float64   `ebml:"Duration,omitempty"`
-	DateUTC       time.Time `ebml:"DateUTC,omitempty"`
+	Metadata      ebml.Metadata `ebml:"-"`
+	TimecodeScale uint64        `ebml:"TimecodeScale"`
+	MuxingApp     string        `ebml:"MuxingApp,omitempty"`
+	WritingApp    string        `ebml:"WritingApp,omitempty"`
+	Duration      float64       `ebml:"Duration,omitempty"`
+	DateUTC       time.Time     `ebml:"DateUTC,omitempty"`
 }
 
 // TrackEntry represents TrackEntry element struct
 type TrackEntry struct {
-	ebml.Metadata
-	Name            string `ebml:"Name,omitempty"`
-	TrackNumber     uint64 `ebml:"TrackNumber"`
-	TrackUID        uint64 `ebml:"TrackUID"`
-	CodecID         string `ebml:"CodecID"`
-	CodecPrivate    []byte `ebml:"CodecPrivate,omitempty"`
-	CodecDelay      uint64 `ebml:"CodecDelay,omitempty"`
-	TrackType       uint64 `ebml:"TrackType"`
-	DefaultDuration uint64 `ebml:"DefaultDuration,omitempty"`
-	SeekPreRoll     uint64 `ebml:"SeekPreRoll,omitempty"`
-	Audio           *Audio `ebml:"Audio"`
-	Video           *Video `ebml:"Video"`
+	Metadata        ebml.Metadata `ebml:"-"`
+	Name            string        `ebml:"Name,omitempty"`
+	TrackNumber     uint64        `ebml:"TrackNumber"`
+	TrackUID        uint64        `ebml:"TrackUID"`
+	CodecID         string        `ebml:"CodecID"`
+	CodecPrivate    []byte        `ebml:"CodecPrivate,omitempty"`
+	CodecDelay      uint64        `ebml:"CodecDelay,omitempty"`
+	TrackType       uint64        `ebml:"TrackType"`
+	DefaultDuration uint64        `ebml:"DefaultDuration,omitempty"`
+	SeekPreRoll     uint64        `ebml:"SeekPreRoll,omitempty"`
+	Audio           *Audio        `ebml:"Audio"`
+	Video           *Video        `ebml:"Video"`
 }
 
 // Audio represents Audio element struct
 type Audio struct {
-	ebml.Metadata
-	SamplingFrequency float64 `ebml:"SamplingFrequency"`
-	Channels          uint64  `ebml:"Channels"`
+	Metadata          ebml.Metadata `ebml:"-"`
+	SamplingFrequency float64       `ebml:"SamplingFrequency"`
+	Channels          uint64        `ebml:"Channels"`
 }
 
 // Video represents Video element struct
 type Video struct {
-	ebml.Metadata
-	PixelWidth  uint64 `ebml:"PixelWidth"`
-	PixelHeight uint64 `ebml:"PixelHeight"`
+	Metadata    ebml.Metadata `ebml:"-"`
+	PixelWidth  uint64        `ebml:"PixelWidth"`
+	PixelHeight uint64        `ebml:"PixelHeight"`
 }
 
 // Tracks represents Tracks element struct
 type Tracks struct {
-	ebml.Metadata
-	TrackEntry []TrackEntry `ebml:"TrackEntry"`
+	Metadata   ebml.Metadata `ebml:"-"`
+	TrackEntry []TrackEntry  `ebml:"TrackEntry"`
 }
 
 // Cluster represents Cluster element struct
 type Cluster struct {
-	ebml.Metadata
-	Timecode   uint64 `ebml:"Timecode"`
-	PrevSize   uint64 `ebml:"PrevSize,omitempty"`
+	Metadata   ebml.Metadata `ebml:"-"`
+	Timecode   uint64        `ebml:"Timecode"`
+	PrevSize   uint64        `ebml:"PrevSize,omitempty"`
 	BlockGroup []struct {
 		ebml.Metadata
 		BlockDuration uint64       `ebml:"BlockDuration"`
@@ -101,37 +101,37 @@ type Cluster struct {
 }
 
 type Cues struct {
-	ebml.Metadata
-	CuePoint []CuePoint `ebml:"CuePoint"`
+	Metadata ebml.Metadata `ebml:"-"`
+	CuePoint []CuePoint    `ebml:"CuePoint"`
 }
 
 type CuePoint struct {
-	ebml.Metadata
+	Metadata          ebml.Metadata      `ebml:"-"`
 	CueTime           uint64             `ebml:"CueTime"`
 	CueTrackPositions []CueTrackPosition `ebml:"CueTrackPositions"`
 }
 
 type CueTrackPosition struct {
-	ebml.Metadata
-	CueTrack           uint64 `ebml:"CueTrack"`
-	CueClusterPosition uint64 `ebml:"CueClusterPosition"`
+	Metadata           ebml.Metadata `ebml:"-"`
+	CueTrack           uint64        `ebml:"CueTrack"`
+	CueClusterPosition uint64        `ebml:"CueClusterPosition"`
 }
 
 // Segment represents Segment element struct
 type Segment struct {
-	ebml.Metadata
-	SeekHead *SeekHead `ebml:"SeekHead"`
-	Info     Info      `ebml:"Info"`
-	Tracks   Tracks    `ebml:"Tracks"`
-	Cluster  []Cluster `ebml:"Cluster"`
-	Cues     *Cues     `ebml:"Cues"`
+	Metadata ebml.Metadata `ebml:"-"`
+	SeekHead *SeekHead     `ebml:"SeekHead"`
+	Info     Info          `ebml:"Info"`
+	Tracks   Tracks        `ebml:"Tracks"`
+	Cluster  []Cluster     `ebml:"Cluster"`
+	Cues     *Cues         `ebml:"Cues"`
 }
 
 // SegmentStream represents Segment element struct for streaming
 type SegmentStream struct {
-	ebml.Metadata
-	SeekHead *SeekHead `ebml:"SeekHead"`
-	Info     Info      `ebml:"Info"`
-	Tracks   Tracks    `ebml:"Tracks"`
-	Cluster  []Cluster `ebml:"Cluster,inf"`
+	Metadata ebml.Metadata `ebml:"-"`
+	SeekHead *SeekHead     `ebml:"SeekHead"`
+	Info     Info          `ebml:"Info"`
+	Tracks   Tracks        `ebml:"Tracks"`
+	Cluster  []Cluster     `ebml:"Cluster,inf"`
 }


### PR DESCRIPTION
Closes #45 

This PR embeds `Metadata`, which has a position in the container, into each master element and set it when unmarshalling a container.
~Each types of reader (`readUint`, `readString`...) additionally returns an int value that means  number of bytes read in the method. Positions are calculated by the value on `ebml.Unmarshal`.~ 