### PR TITLE
Add UnmarshalHook

### DIFF
--- a/block.go
+++ b/block.go
@@ -79,7 +79,7 @@ type Lace struct {
 func UnmarshalBlock(r io.Reader) (*Block, error) {
 	var b Block
 	var err error
-	if b.TrackNumber, err = readVInt(r); err != nil {
+	if b.TrackNumber, _, err = readVInt(r); err != nil {
 		return nil, err
 	}
 	if v, err := readInt(r, 2); err == nil {

--- a/elementtable.go
+++ b/elementtable.go
@@ -91,7 +91,7 @@ func init() {
 	revTable = make(elementRevTable)
 
 	for k, v := range table {
-		e, err := readVInt(bytes.NewBuffer(v.b))
+		e, _, err := readVInt(bytes.NewBuffer(v.b))
 		if err != nil {
 			panic(err)
 		}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -175,7 +175,7 @@ type Element struct {
 	Parent   *Element
 }
 
-// WithElementReadHooks creates an UnmarshalOptions in which element hooks are registered
+// WithElementReadHooks returns an UnmarshalOption which registers element hooks
 func WithElementReadHooks(hooks ...func(*Element)) UnmarshalOption {
 	return func(opts *UnmarshalOptions) {
 		opts.hooks = hooks

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -175,8 +175,8 @@ type Element struct {
 	Parent   *Element
 }
 
-// WithElementHooks creates an UnmarshalOptions in which element hooks are registered
-func WithElementHooks(hooks ...func(*Element)) UnmarshalOption {
+// WithElementReadHooks creates an UnmarshalOptions in which element hooks are registered
+func WithElementReadHooks(hooks ...func(*Element)) UnmarshalOption {
 	return func(opts *UnmarshalOptions) {
 		opts.hooks = hooks
 	}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -80,7 +80,7 @@ func readElement(r0 io.Reader, n int64, vo reflect.Value) (io.Reader, error) {
 	}
 
 	for {
-		e, err := readVInt(r)
+		e, _, err := readVInt(r)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func readElement(r0 io.Reader, n int64, vo reflect.Value) (io.Reader, error) {
 			return nil, errUnknownElement
 		}
 
-		size, err := readVInt(r)
+		size, _, err := readVInt(r)
 		if err != nil {
 			return nil, err
 		}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -46,6 +46,58 @@ func ExampleUnmarshal() {
 	// Output: {{webm 2 2}}
 }
 
+func TestUnmarshal_Hook(t *testing.T) {
+	TestBinary := []byte{
+		0x18, 0x53, 0x80, 0x67, 0xa1, // Segment
+		0x16, 0x54, 0xae, 0x6b, 0x9c, // Tracks
+		0xae, 0x8c, // TrackEntry[0]
+		0x53, 0x6e, 0x86, 0x56, 0x69, 0x64, 0x65, 0x6f, 0x00, // Name=Video
+		0xd7, 0x81, 0x01, // TrackNumber=1
+		0xae, 0x8c, // TrackEntry[1]
+		0x53, 0x6e, 0x86, 0x41, 0x75, 0x64, 0x69, 0x6f, 0x00, // Name=Audio
+		0xd7, 0x81, 0x02, // TrackNumber=2
+	}
+
+	type TestEBML struct {
+		Segment struct {
+			Tracks struct {
+				TrackEntry []struct {
+					Name        string `ebml:"Name,omitempty"`
+					TrackNumber uint64 `ebml:"TrackNumber"`
+				} `ebml:"TrackEntry"`
+			} `ebml:"Tracks"`
+		} `ebml:"Segment"`
+	}
+
+	r := bytes.NewReader(TestBinary)
+
+	var ret TestEBML
+	m := make(map[string][]*Element)
+	if err := Unmarshal(r, &ret, WithElementMap(m)); err != nil {
+		t.Errorf("error: %+v\n", err)
+	}
+
+	// Verify positions of elements
+	expected := map[string][]uint64{
+		"Segment.Tracks":            {5},
+		"Segment.Tracks.TrackEntry": {10, 24},
+	}
+	for key, positions := range expected {
+		elem, ok := m[key]
+		if !ok {
+			t.Errorf("Key '%s' doesn't exist\n", key)
+		}
+		if len(elem) != len(positions) {
+			t.Errorf("Unexpected element size of '%s', expected: %d, got: %d\n", key, len(positions), len(elem))
+		}
+		for i, pos := range positions {
+			if elem[i].Position != pos {
+				t.Errorf("Unexpected element positon of '%s[%d]', expected: %d, got: %d\n", key, i, pos, elem[i].Position)
+			}
+		}
+	}
+}
+
 func TestUnmarshal_Tag(t *testing.T) {
 	var tagged struct {
 		DocCustomNamedType string `ebml:"EBMLDocType"`

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -46,7 +46,7 @@ func ExampleUnmarshal() {
 	// Output: {{webm 2 2}}
 }
 
-func TestUnmarshal_WithElementHooks(t *testing.T) {
+func TestUnmarshal_WithElementReadHooks(t *testing.T) {
 	TestBinary := []byte{
 		0x18, 0x53, 0x80, 0x67, 0xa1, // Segment
 		0x16, 0x54, 0xae, 0x6b, 0x9c, // Tracks
@@ -74,7 +74,7 @@ func TestUnmarshal_WithElementHooks(t *testing.T) {
 	var ret TestEBML
 	m := make(map[string][]*Element)
 	hook := withElementMap(m)
-	if err := Unmarshal(r, &ret, WithElementHooks(hook)); err != nil {
+	if err := Unmarshal(r, &ret, WithElementReadHooks(hook)); err != nil {
 		t.Errorf("error: %+v\n", err)
 	}
 

--- a/value.go
+++ b/value.go
@@ -43,11 +43,11 @@ var perTypeReader = map[Type]func(io.Reader, uint64) (interface{}, error){
 	TypeBlock:  readBlock,
 }
 
-func readVInt(r io.Reader) (uint64, error) {
+func readVInt(r io.Reader) (uint64, int, error) {
 	var bs [1]byte
-	_, err := r.Read(bs[:])
+	bytesRead, err := r.Read(bs[:])
 	if err != nil {
-		return 0, err
+		return 0, bytesRead, err
 	}
 
 	var vc int
@@ -82,14 +82,15 @@ func readVInt(r io.Reader) (uint64, error) {
 
 	for {
 		if vc == 0 {
-			return value, nil
+			return value, bytesRead, nil
 		}
 
 		var bs [1]byte
-		_, err := r.Read(bs[:])
+		n, err := r.Read(bs[:])
 		if err != nil {
-			return 0, err
+			return 0, bytesRead, err
 		}
+		bytesRead += n
 		value = value<<8 | uint64(bs[0])
 		vc--
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -32,7 +32,7 @@ func TestDataSize(t *testing.T) {
 
 	for n, c := range testCases {
 		t.Run("Decode "+n, func(t *testing.T) {
-			r, err := readVInt(bytes.NewBuffer(c.b))
+			r, _, err := readVInt(bytes.NewBuffer(c.b))
 			if err != nil {
 				t.Fatalf("Failed to readVInt: %v", err)
 			}
@@ -73,7 +73,7 @@ func TestElementID(t *testing.T) {
 
 	for n, c := range testCases {
 		t.Run("Decode "+n, func(t *testing.T) {
-			r, err := readVInt(bytes.NewBuffer(c.b))
+			r, _, err := readVInt(bytes.NewBuffer(c.b))
 			if err != nil {
 				t.Fatalf("Failed to readVInt: %v", err)
 			}


### PR DESCRIPTION
Retry of #45 

This PR adds a hook mechanism to the Unmarshal method.

- Hooks is a function that receives metadata of each master element
  - Element Name
  - Position in the binary
  - Element Size
  - Actual value object
  - Pointer of parent element
- Hooks will be executed when each master elements is unmarshaled. 
- Created a hook `WithElementMap` that creates a map that has element name as key and its element as value.