### PR TITLE
Support marshalling value via function

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -270,7 +270,7 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 				ret := vn.Call(nil)
 				lenRet := len(ret)
 				if lenRet != 1 && lenRet != 2 {
-					return pos, wrapErrorf(ErrIncompatibleType, "Number of return value must be 1 or 2 but %d", lenRet)
+					return pos, wrapErrorf(ErrIncompatibleType, "number of return value must be 1 or 2 but %d", lenRet)
 				}
 				val := ret[0]
 				if lenRet == 2 {

--- a/marshal.go
+++ b/marshal.go
@@ -274,12 +274,9 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 						ErrIncompatibleType, "marshalling %s from func", val.Type(),
 					)
 				}
-				if len(lst) != 1 {
-					return pos, wrapErrorf(
-						ErrIncompatibleType, "marshalling %s from func", val.Type(),
-					)
+				for _, l := range lst {
+					pos, err = writeOne(l)
 				}
-				pos, err = writeOne(lst[0])
 			default:
 				pos, err = writeOne(vn)
 			}

--- a/marshal.go
+++ b/marshal.go
@@ -266,6 +266,20 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 					}
 					pos, err = writeOne(lst[0])
 				}
+			case reflect.Func:
+				val := vn.Call(nil)[0]
+				lst, ok := pealElem(val, e.t == DataTypeBinary, tag.omitEmpty)
+				if !ok {
+					return pos, wrapErrorf(
+						ErrIncompatibleType, "marshalling %s from func", val.Type(),
+					)
+				}
+				if len(lst) != 1 {
+					return pos, wrapErrorf(
+						ErrIncompatibleType, "marshalling %s from func", val.Type(),
+					)
+				}
+				pos, err = writeOne(lst[0])
 			default:
 				pos, err = writeOne(vn)
 			}

--- a/marshal.go
+++ b/marshal.go
@@ -268,8 +268,12 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 				}
 			case reflect.Func:
 				ret := vn.Call(nil)
+				lenRet := len(ret)
+				if lenRet != 1 && lenRet != 2 {
+					return pos, wrapErrorf(ErrIncompatibleType, "Number of return value must be 1 or 2 but %d", lenRet)
+				}
 				val := ret[0]
-				if len(ret) == 2 {
+				if lenRet == 2 {
 					errVal := ret[1]
 					if errVal.Type().String() != "error" {
 						return pos, wrapErrorf(ErrIncompatibleType, "2nd return value must be error but %s", errVal.Type())

--- a/marshal.go
+++ b/marshal.go
@@ -278,8 +278,7 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 					if errVal.Type().String() != "error" {
 						return pos, wrapErrorf(ErrIncompatibleType, "2nd return value must be error but %s", errVal.Type())
 					}
-					iFace := errVal.Interface()
-					if iFace != nil {
+					if iFace := errVal.Interface(); iFace != nil {
 						return pos, iFace.(error)
 					}
 				}

--- a/marshal.go
+++ b/marshal.go
@@ -267,7 +267,18 @@ func marshalImpl(vo reflect.Value, w io.Writer, pos uint64, parent *Element, opt
 					pos, err = writeOne(lst[0])
 				}
 			case reflect.Func:
-				val := vn.Call(nil)[0]
+				ret := vn.Call(nil)
+				val := ret[0]
+				if len(ret) == 2 {
+					errVal := ret[1]
+					if errVal.Type().String() != "error" {
+						return pos, wrapErrorf(ErrIncompatibleType, "2nd return value must be error but %s", errVal.Type())
+					}
+					iFace := errVal.Interface()
+					if iFace != nil {
+						return pos, iFace.(error)
+					}
+				}
 				lst, ok := pealElem(val, e.t == DataTypeBinary, tag.omitEmpty)
 				if !ok {
 					return pos, wrapErrorf(

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -650,7 +650,7 @@ func TestMarshal_Func(t *testing.T) {
 			}
 		})
 		t.Run("Error", func(t *testing.T) {
-			expectedErr := errors.New("a error")
+			expectedErr := errors.New("an error")
 			input.Segment.Cluster = func() (Cluster, error) {
 				return Cluster{Timecode: 0x01}, expectedErr
 			}
@@ -659,7 +659,7 @@ func TestMarshal_Func(t *testing.T) {
 				t.Fatalf("Expected error: '%v', got: '%v'", expectedErr, err)
 			}
 		})
-		t.Run("NotError", func(t *testing.T) {
+		t.Run("NonErrorType", func(t *testing.T) {
 			input := &struct {
 				Segment struct {
 					Cluster func() (*Cluster, int) `ebml:"Cluster,size=unknown"`

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -608,11 +608,25 @@ func TestMarshal_Func(t *testing.T) {
 			} `ebml:"Segment,size=unknown"`
 		}{}
 		input.Segment.Cluster = func() []Cluster {
-			return make([]Cluster, 2)
+			return []Cluster{
+				{Timecode: 0x01},
+				{Timecode: 0x02},
+			}
 		}
 
-		if err := Marshal(input, &bytes.Buffer{}); !errs.Is(err, ErrIncompatibleType) {
-			t.Fatalf("Expected error: '%v', got: '%v'", ErrIncompatibleType, err)
+		var b bytes.Buffer
+		if err := Marshal(input, &b); err != nil {
+			t.Fatalf("Unexpected error: '%v'", err)
+		}
+		expected := []byte{
+			0x18, 0x53, 0x80, 0x67, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+			0x1F, 0x43, 0xB6, 0x75, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+			0xE7, 0x81, 0x01,
+			0x1F, 0x43, 0xB6, 0x75, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+			0xE7, 0x81, 0x02,
+		}
+		if !bytes.Equal(expected, b.Bytes()) {
+			t.Errorf("Marshaled binary doesn't match:\n expected: %v,\n      got: %v", expected, b.Bytes())
 		}
 	})
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -674,6 +674,18 @@ func TestMarshal_Func(t *testing.T) {
 			}
 		})
 	})
+	t.Run("InvalidFunc", func(t *testing.T) {
+		input := &struct {
+			Segment struct {
+				Cluster func() `ebml:"Cluster,size=unknown"`
+			} `ebml:"Segment,size=unknown"`
+		}{}
+		input.Segment.Cluster = func() {}
+
+		if err := Marshal(input, &bytes.Buffer{}); !errs.Is(err, ErrIncompatibleType) {
+			t.Fatalf("Expected error: '%v', got: '%v'", ErrIncompatibleType, err)
+		}
+	})
 }
 
 func BenchmarkMarshal(b *testing.B) {


### PR DESCRIPTION
This PR makes ebml-go possible to marshal a value via function.

Currently the function is expected to be:

- no input argument
- actual value must be the first position in return values
  - ~it might be better to consider `error` object that is returned as 2nd return value.~ implemented

I'd like to use this feature like following.

```go
type SegmentWrite struct {
	Cluster func() Cluster `ebml:"Cluster,size=unknown"`
}

input.SegmentWrite.Cluster = func() Cluster {
	return Cluster{Timecode: uint64(time.Now().Unix())}
}
ebml.Marshal(input, buf)
```

@at-wat 
I would appreciate if you review this, thank you 😃 