### PR TITLE
Added save sorter that drops based on duration

### DIFF
--- a/mkvcore/blockwriter_test.go
+++ b/mkvcore/blockwriter_test.go
@@ -34,9 +34,14 @@ func TestBlockWriter(t *testing.T) {
 		{TrackNumber: 1},
 		{TrackNumber: 2},
 	}
+
+	blockSorter, err := NewMultiTrackBlockSorter(WithMaxDelayedPackets(10), WithSortRule(BlockSorterDropOutdated))
+	if err != nil {
+		t.Fatalf("Failed to create MultiTrackBlockSorter: %v", err)
+	}
+
 	ws, err := NewSimpleBlockWriter(buf, tracks,
-		WithBlockInterceptor(NewMultiTrackBlockSorter(10, BlockSorterDropOutdated)),
-	)
+		WithBlockInterceptor(blockSorter))
 	if err != nil {
 		t.Fatalf("Failed to create BlockWriter: '%v'", err)
 	}
@@ -524,8 +529,14 @@ func BenchmarkBlockWriter_InitFinalize(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf := buffercloser.New()
+
+		blockSorter, err := NewMultiTrackBlockSorter(WithMaxDelayedPackets(10), WithSortRule(BlockSorterDropOutdated))
+		if err != nil {
+			b.Fatalf("Failed to create MultiTrackBlockSorter: %v", err)
+		}
+
 		ws, err := NewSimpleBlockWriter(buf, tracks,
-			WithBlockInterceptor(NewMultiTrackBlockSorter(10, BlockSorterDropOutdated)),
+			WithBlockInterceptor(blockSorter),
 		)
 		if err != nil {
 			b.Fatalf("Failed to create BlockWriter: %v", err)
@@ -542,8 +553,14 @@ func BenchmarkBlockWriter_SimpleBlock(b *testing.B) {
 	}
 
 	buf := buffercloser.New()
+
+	blockSorter, err := NewMultiTrackBlockSorter(WithMaxDelayedPackets(10), WithSortRule(BlockSorterDropOutdated))
+	if err != nil {
+		b.Fatalf("Failed to create MultiTrackBlockSorter: %v", err)
+	}
+
 	ws, err := NewSimpleBlockWriter(buf, tracks,
-		WithBlockInterceptor(NewMultiTrackBlockSorter(10, BlockSorterDropOutdated)),
+		WithBlockInterceptor(blockSorter),
 	)
 	if err != nil {
 		b.Fatalf("Failed to create BlockWriter: %v", err)

--- a/mkvcore/framebuf.go
+++ b/mkvcore/framebuf.go
@@ -27,6 +27,12 @@ func (b *frameBuffer) Head() *frame {
 	}
 	return b.buf[0]
 }
+func (b *frameBuffer) Tail() *frame {
+	if len(b.buf) == 0 {
+		return nil
+	}
+	return b.buf[len(b.buf)-1]
+}
 func (b *frameBuffer) Pop() *frame {
 	n := len(b.buf)
 	if n == 0 {

--- a/mkvcore/interceptor.go
+++ b/mkvcore/interceptor.go
@@ -26,8 +26,8 @@ type BlockInterceptor interface {
 	Intercept(r []BlockReader, w []BlockWriter)
 }
 
-// Panics if creation of a BlockInterceptor fails, such as when the
-// NewMultiTrackBlockSorter function fails.
+// MustBlockInterceptor panics if creation of a BlockInterceptor fails, such as
+// when the NewMultiTrackBlockSorter function fails.
 func MustBlockInterceptor(interceptor BlockInterceptor, err error) BlockInterceptor {
 	if err != nil {
 		panic(err)

--- a/mkvcore/interceptor.go
+++ b/mkvcore/interceptor.go
@@ -26,6 +26,8 @@ type BlockInterceptor interface {
 	Intercept(r []BlockReader, w []BlockWriter)
 }
 
+// Panics if creation of a BlockInterceptor fails, such as when the
+// NewMultiTrackBlockSorter function fails.
 func MustBlockInterceptor(interceptor BlockInterceptor, err error) BlockInterceptor {
 	if err != nil {
 		panic(err)

--- a/mkvcore/interceptor_test.go
+++ b/mkvcore/interceptor_test.go
@@ -54,7 +54,11 @@ func TestMultiTrackBlockSorter(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			wg := sync.WaitGroup{}
-			f := NewMultiTrackBlockSorter(2, c.rule)
+
+			f, err := NewMultiTrackBlockSorter(WithMaxDelayedPackets(2), WithSortRule(c.rule))
+			if err != nil {
+				t.Errorf("Failed to create MultiTrackBlockSorter: %v", err)
+			}
 
 			chOut := make(chan *frame)
 			ch := []chan *frame{
@@ -109,7 +113,10 @@ func TestMultiTrackBlockSorter(t *testing.T) {
 }
 
 func BenchmarkMultiTrackBlockSorter(b *testing.B) {
-	f := NewMultiTrackBlockSorter(2, BlockSorterDropOutdated)
+	f, err := NewMultiTrackBlockSorter(WithMaxDelayedPackets(2), WithSortRule(BlockSorterDropOutdated))
+	if err != nil {
+		b.Errorf("Failed to create MultiTrackBlockSorter: %v", err)
+	}
 
 	chOut := make(chan *frame)
 	ch := []chan *frame{

--- a/webm/const.go
+++ b/webm/const.go
@@ -36,5 +36,5 @@ var (
 		WritingApp:    "ebml-go.webm.BlockWriter",
 	}
 	// DefaultBlockInterceptor is the default BlockInterceptor used by BlockWriter.
-	DefaultBlockInterceptor, _ = mkvcore.NewMultiTrackBlockSorter(mkvcore.WithMaxDelayedPackets(16), mkvcore.WithSortRule(mkvcore.BlockSorterDropOutdated))
+	DefaultBlockInterceptor = mkcore.MustBlockInterceptor(mkvcore.NewMultiTrackBlockSorter(mkvcore.WithMaxDelayedPackets(16), mkvcore.WithSortRule(mkvcore.BlockSorterDropOutdated)))
 )

--- a/webm/const.go
+++ b/webm/const.go
@@ -36,5 +36,5 @@ var (
 		WritingApp:    "ebml-go.webm.BlockWriter",
 	}
 	// DefaultBlockInterceptor is the default BlockInterceptor used by BlockWriter.
-	DefaultBlockInterceptor = mkcore.MustBlockInterceptor(mkvcore.NewMultiTrackBlockSorter(mkvcore.WithMaxDelayedPackets(16), mkvcore.WithSortRule(mkvcore.BlockSorterDropOutdated)))
+	DefaultBlockInterceptor = mkvcore.MustBlockInterceptor(mkvcore.NewMultiTrackBlockSorter(mkvcore.WithMaxDelayedPackets(16), mkvcore.WithSortRule(mkvcore.BlockSorterDropOutdated)))
 )

--- a/webm/const.go
+++ b/webm/const.go
@@ -36,5 +36,5 @@ var (
 		WritingApp:    "ebml-go.webm.BlockWriter",
 	}
 	// DefaultBlockInterceptor is the default BlockInterceptor used by BlockWriter.
-	DefaultBlockInterceptor = mkvcore.NewMultiTrackBlockSorter(16, mkvcore.BlockSorterDropOutdated)
+	DefaultBlockInterceptor, _ = mkvcore.NewMultiTrackBlockSorter(mkvcore.WithMaxDelayedPackets(16), mkvcore.WithSortRule(mkvcore.BlockSorterDropOutdated))
 )


### PR DESCRIPTION
A saver that drops frames based on packets is a problem because the
numbre of packets is very dependent on the codec and the frame rate (if
the codec is video). By making the discarding of old packets based on
time a discard window is more accurate regardless of the packets.

A feature was added to allow either by time or by total packets as
an optional argument as passed into the constructor.