### PR TITLE
feat: WithCues BlockWriter option

### DIFF
--- a/mkvcore/blockwriter.go
+++ b/mkvcore/blockwriter.go
@@ -15,8 +15,11 @@
 package mkvcore
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/at-wat/ebml-go"
@@ -86,6 +89,19 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 		}
 	}
 
+	// Validate Cues requirements
+	var seeker io.WriteSeeker
+	if options.cuesReservedSize > 0 {
+		if !options.seekHead {
+			return nil, ErrCuesRequiresSeekHead
+		}
+		var ok bool
+		seeker, ok = w0.(io.WriteSeeker)
+		if !ok {
+			return nil, ErrCuesRequiresSeeker
+		}
+	}
+
 	w := &writerWithSizeCount{w: w0}
 
 	header := flexHeader{
@@ -97,14 +113,39 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 	for _, t := range tracks {
 		header.Segment.Tracks.TrackEntry = append(header.Segment.Tracks.TrackEntry, t.TrackEntry)
 	}
+
+	// When Cues are enabled and segmentInfo supports it, set a placeholder
+	// Duration so the marshaler includes the element in the output.
+	// We'll overwrite it with the real value at finalization.
+	if options.cuesReservedSize > 0 {
+		if ds, ok := options.segmentInfo.(durationSettable); ok {
+			ds.SetDuration(math.SmallestNonzeroFloat64)
+		}
+	}
+
+	var durationElementPos uint64
+	var segmentDataStart uint64
 	if options.seekHead {
-		if err := setSeekHead(&header, options.marshalOpts...); err != nil {
+		var err error
+		segmentDataStart, durationElementPos, err = setSeekHead(&header, options.cuesReservedSize > 0, options.marshalOpts...)
+		if err != nil {
 			return nil, err
 		}
 	}
 	if err := ebml.Marshal(&header, w, options.marshalOpts...); err != nil {
 		return nil, err
 	}
+
+	// Reserve space for Cues by writing a Void element
+	var cuesReservedStart uint64
+	var posAfterHeader uint64
+	if options.cuesReservedSize > 0 {
+		cuesReservedStart = uint64(w.Size())
+		if err := writeVoidElement(w, options.cuesReservedSize); err != nil {
+			return nil, err
+		}
+	}
+	posAfterHeader = uint64(w.Size())
 
 	w.Clear()
 
@@ -161,6 +202,10 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 		tc1 := invalidTimestamp
 		lastTc := int64(0)
 
+		// Cues tracking state
+		runningPos := posAfterHeader
+		var cuePoints []cuePoint
+
 		defer func() {
 			// Finalize WebM
 			if tc0 == invalidTimestamp {
@@ -180,6 +225,37 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 					options.onFatal(err)
 				}
 			}
+
+			// Write Cues to the reserved space
+			if options.cuesReservedSize > 0 && len(cuePoints) > 0 {
+				writeCuesToReserved(
+					seeker, cuePoints, options.marshalOpts,
+					cuesReservedStart, options.cuesReservedSize,
+					options.onFatal,
+				)
+			}
+
+			// Overwrite the placeholder Duration with the real value.
+			// Duration element layout: 2-byte ID (0x44 0x89) + 1-byte VINT (0x88) + 8-byte float64.
+			if durationElementPos > 0 && seeker != nil {
+				duration := float64(lastTc - tc0)
+				var buf [8]byte
+				binary.BigEndian.PutUint64(buf[:], math.Float64bits(duration))
+				if _, err := seeker.Seek(int64(durationElementPos)+3, io.SeekStart); err != nil {
+					if options.onFatal != nil {
+						options.onFatal(err)
+					}
+				} else if _, err := seeker.Write(buf[:]); err != nil {
+					if options.onFatal != nil {
+						options.onFatal(err)
+					}
+				} else if _, err := seeker.Seek(0, io.SeekEnd); err != nil {
+					if options.onFatal != nil {
+						options.onFatal(err)
+					}
+				}
+			}
+
 			w.Close()
 			<-fin // read one data to release blocked Close()
 		}()
@@ -199,6 +275,18 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 					// Create new Cluster
 					tc1 = f.timestamp
 					tc = 0
+
+					// Collect CuePoint before Clear
+					if options.cuesReservedSize > 0 {
+						runningPos += uint64(w.Size())
+						cuePoints = append(cuePoints, cuePoint{
+							CueTime: uint64(tc1 - tc0),
+							CueTrackPositions: []cueTrackPosition{{
+								CueTrack:           f.trackNumber,
+								CueClusterPosition: runningPos - segmentDataStart,
+							}},
+						})
+					}
 
 					cluster := struct {
 						Cluster simpleBlockCluster `ebml:"Cluster,size=unknown"`
@@ -246,4 +334,82 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 	}()
 
 	return ws, nil
+}
+
+// writeVoidElement writes an EBML Void element of exactly totalSize bytes.
+// Always uses 8-byte VINT for simplicity; callers must ensure totalSize >= 9.
+func writeVoidElement(w io.Writer, totalSize int) error {
+	buf := make([]byte, totalSize)
+	buf[0] = 0xEC // Void Element ID
+	dataSize := uint64(totalSize - 9)
+	buf[1] = 0x01
+	buf[2] = byte(dataSize >> 48)
+	buf[3] = byte(dataSize >> 40)
+	buf[4] = byte(dataSize >> 32)
+	buf[5] = byte(dataSize >> 24)
+	buf[6] = byte(dataSize >> 16)
+	buf[7] = byte(dataSize >> 8)
+	buf[8] = byte(dataSize)
+	_, err := w.Write(buf)
+	return err
+}
+
+// writeCuesToReserved marshals Cues and writes them into the reserved Void space.
+func writeCuesToReserved(
+	seeker io.WriteSeeker,
+	cuePoints []cuePoint,
+	marshalOpts []ebml.MarshalOption,
+	reservedStart uint64, reservedSize int,
+	onFatal func(error),
+) {
+	cuesData := struct {
+		Cues cues `ebml:"Cues"`
+	}{
+		Cues: cues{CuePoint: cuePoints},
+	}
+	var buf bytes.Buffer
+	if err := ebml.Marshal(&cuesData, &buf, marshalOpts...); err != nil {
+		if onFatal != nil {
+			onFatal(err)
+		}
+		return
+	}
+
+	cuesBytes := buf.Bytes()
+	remaining := reservedSize - len(cuesBytes)
+	if remaining < 0 || (remaining > 0 && remaining < 9) {
+		// Cues don't fit, or leftover space is too small for a Void element
+		// (need 9 bytes minimum: 1-byte ID + 8-byte VINT).
+		// Skip silently — the file remains valid, just not seekable.
+		return
+	}
+
+	if _, err := seeker.Seek(int64(reservedStart), io.SeekStart); err != nil {
+		if onFatal != nil {
+			onFatal(err)
+		}
+		return
+	}
+	if _, err := seeker.Write(cuesBytes); err != nil {
+		if onFatal != nil {
+			onFatal(err)
+		}
+		return
+	}
+
+	if remaining > 0 {
+		if err := writeVoidElement(seeker, remaining); err != nil {
+			if onFatal != nil {
+				onFatal(err)
+			}
+			return
+		}
+	}
+
+	// Seek back to end of file
+	if _, err := seeker.Seek(0, io.SeekEnd); err != nil {
+		if onFatal != nil {
+			onFatal(err)
+		}
+	}
 }

--- a/mkvcore/blockwriter_test.go
+++ b/mkvcore/blockwriter_test.go
@@ -17,6 +17,7 @@ package mkvcore
 import (
 	"bytes"
 	"errors"
+	"io"
 	"reflect"
 	"sync"
 	"testing"
@@ -579,4 +580,581 @@ func BenchmarkBlockWriter_SimpleBlock(b *testing.B) {
 	for _, w := range ws {
 		w.Close()
 	}
+}
+
+// seekableBuffer implements io.WriteCloser and io.WriteSeeker for testing.
+type seekableBuffer struct {
+	buf    []byte
+	pos    int
+	closed chan struct{}
+}
+
+func newSeekableBuffer() *seekableBuffer {
+	return &seekableBuffer{
+		closed: make(chan struct{}),
+	}
+}
+
+func (b *seekableBuffer) Write(p []byte) (int, error) {
+	end := b.pos + len(p)
+	if end > len(b.buf) {
+		b.buf = append(b.buf, make([]byte, end-len(b.buf))...)
+	}
+	copy(b.buf[b.pos:], p)
+	b.pos = end
+	return len(p), nil
+}
+
+func (b *seekableBuffer) Seek(offset int64, whence int) (int64, error) {
+	var newPos int64
+	switch whence {
+	case io.SeekStart:
+		newPos = offset
+	case io.SeekCurrent:
+		newPos = int64(b.pos) + offset
+	case io.SeekEnd:
+		newPos = int64(len(b.buf)) + offset
+	}
+	b.pos = int(newPos)
+	return newPos, nil
+}
+
+func (b *seekableBuffer) Close() error {
+	close(b.closed)
+	return nil
+}
+
+func (b *seekableBuffer) Closed() <-chan struct{} {
+	return b.closed
+}
+
+func (b *seekableBuffer) Bytes() []byte {
+	return b.buf
+}
+
+// cuesTestSegment is the EBML segment structure used across Cues tests.
+type cuesTestSegment struct {
+	SeekHead *struct {
+		Seek []struct {
+			SeekID       []byte `ebml:"SeekID"`
+			SeekPosition uint64 `ebml:"SeekPosition"`
+		} `ebml:"Seek"`
+	} `ebml:"SeekHead"`
+	Info interface{} `ebml:"Info"`
+	Cues *struct {
+		CuePoint []struct {
+			CueTime           uint64 `ebml:"CueTime"`
+			CueTrackPositions []struct {
+				CueTrack           uint64 `ebml:"CueTrack"`
+				CueClusterPosition uint64 `ebml:"CueClusterPosition"`
+			} `ebml:"CueTrackPositions"`
+		} `ebml:"CuePoint"`
+	} `ebml:"Cues"`
+	Tracks  flexTracks           `ebml:"Tracks"`
+	Cluster []simpleBlockCluster `ebml:"Cluster,size=unknown"`
+}
+
+func TestBlockWriter_WithCues(t *testing.T) {
+	t.Run("ValidationRequiresSeekHead", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		_, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(nil),
+			WithCues(1024),
+			// No WithSeekHead
+		)
+		if !errs.Is(err, ErrCuesRequiresSeekHead) {
+			t.Errorf("Expected error: '%v', got: '%v'", ErrCuesRequiresSeekHead, err)
+		}
+	})
+
+	t.Run("ValidationRequiresSeeker", func(t *testing.T) {
+		buf := buffercloser.New() // not an io.WriteSeeker
+		_, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(nil),
+			WithSeekHead(true),
+			WithCues(1024),
+		)
+		if !errs.Is(err, ErrCuesRequiresSeeker) {
+			t.Errorf("Expected error: '%v', got: '%v'", ErrCuesRequiresSeeker, err)
+		}
+	})
+
+	t.Run("CuesWritten", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(&struct {
+				TimecodeScale uint64 `ebml:"TimecodeScale"`
+			}{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+		if len(ws) != 1 {
+			t.Fatalf("Number of the returned writer must be 1, got %d", len(ws))
+		}
+
+		// Write blocks that span multiple clusters
+		// Each cluster boundary creates a CuePoint
+		for i := 0; i < 5; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+
+		ws[0].Close()
+		<-buf.Closed()
+
+		// Unmarshal and verify Cues are present
+		var result struct {
+			Segment cuesTestSegment `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(buf.Bytes()), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+
+		if result.Segment.Cues == nil {
+			t.Fatal("Expected Cues to be present, got nil")
+		}
+
+		// Should have 5 CuePoints (one for each cluster)
+		if got := len(result.Segment.Cues.CuePoint); got != 5 {
+			t.Errorf("Expected 5 CuePoints, got %d", got)
+		}
+
+		// Verify CueTimes are increasing
+		for i := 1; i < len(result.Segment.Cues.CuePoint); i++ {
+			prev := result.Segment.Cues.CuePoint[i-1].CueTime
+			curr := result.Segment.Cues.CuePoint[i].CueTime
+			if curr <= prev {
+				t.Errorf("CuePoint[%d].CueTime (%d) <= CuePoint[%d].CueTime (%d)", i, curr, i-1, prev)
+			}
+		}
+
+		// Verify CueClusterPositions are increasing
+		for i := 1; i < len(result.Segment.Cues.CuePoint); i++ {
+			prev := result.Segment.Cues.CuePoint[i-1].CueTrackPositions[0].CueClusterPosition
+			curr := result.Segment.Cues.CuePoint[i].CueTrackPositions[0].CueClusterPosition
+			if curr <= prev {
+				t.Errorf("CuePoint[%d].CueClusterPosition (%d) <= CuePoint[%d].CueClusterPosition (%d)", i, curr, i-1, prev)
+			}
+		}
+
+		// Verify SeekHead contains Cues entry
+		if result.Segment.SeekHead == nil {
+			t.Fatal("Expected SeekHead to be present, got nil")
+		}
+		foundCues := false
+		cuesID := ebml.ElementCues.Bytes()
+		for _, seek := range result.Segment.SeekHead.Seek {
+			if bytes.Equal(seek.SeekID, cuesID) {
+				foundCues = true
+				break
+			}
+		}
+		if !foundCues {
+			t.Error("SeekHead does not contain Cues entry")
+		}
+	})
+
+	t.Run("CuesOverflow", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(nil),
+			WithSeekHead(true),
+			WithCues(32), // Tiny reserved space - will overflow
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		// Write blocks to create multiple clusters
+		for i := 0; i < 5; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+		ws[0].Close()
+		<-buf.Closed()
+
+		// File should still be valid, just without Cues
+		var result struct {
+			Segment struct {
+				Tracks  flexTracks           `ebml:"Tracks"`
+				Cluster []simpleBlockCluster `ebml:"Cluster,size=unknown"`
+			} `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(buf.Bytes()), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+		// Should have clusters (file is valid)
+		if len(result.Segment.Cluster) == 0 {
+			t.Error("Expected clusters in output")
+		}
+	})
+
+	t.Run("PositionVerification", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(&struct {
+				TimecodeScale uint64 `ebml:"TimecodeScale"`
+			}{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		// Write 3 frames, each triggering a new cluster (timecodes far apart)
+		for i := 0; i < 3; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+		ws[0].Close()
+		<-buf.Closed()
+
+		data := buf.Bytes()
+
+		// Find Segment data start by locating the Segment element ID
+		segmentID := []byte{0x18, 0x53, 0x80, 0x67}
+		segmentIdx := bytes.Index(data, segmentID)
+		if segmentIdx < 0 {
+			t.Fatal("Segment element not found")
+		}
+		// Segment uses unknown size: 4 byte ID + 8 byte size VINT = 12 byte header
+		segmentDataStart := segmentIdx + 4 + 8
+
+		// Unmarshal to get SeekHead and Cues data
+		var result struct {
+			Segment cuesTestSegment `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(data), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+
+		if result.Segment.Cues == nil {
+			t.Fatal("Cues not found in output")
+		}
+		if result.Segment.SeekHead == nil {
+			t.Fatal("SeekHead not found in output")
+		}
+
+		clusterElementID := []byte{0x1F, 0x43, 0xB6, 0x75}
+
+		// SeekHead Cues position points to actual Cues element
+		t.Run("SeekHeadCuesPosition", func(t *testing.T) {
+			cuesElementID := []byte{0x1C, 0x53, 0xBB, 0x6B}
+			var seekHeadCuesPos uint64
+			for _, seek := range result.Segment.SeekHead.Seek {
+				if bytes.Equal(seek.SeekID, ebml.ElementCues.Bytes()) {
+					seekHeadCuesPos = seek.SeekPosition
+					break
+				}
+			}
+			cuesAbsolutePos := segmentDataStart + int(seekHeadCuesPos)
+
+			if cuesAbsolutePos+4 > len(data) {
+				t.Fatalf("Cues position %d is beyond file size %d", cuesAbsolutePos, len(data))
+			}
+			actualCuesID := data[cuesAbsolutePos : cuesAbsolutePos+4]
+			if !bytes.Equal(actualCuesID, cuesElementID) {
+				t.Errorf("SeekHead Cues position points to bytes %X, expected Cues element ID %X", actualCuesID, cuesElementID)
+			}
+		})
+
+		// CueClusterPositions point to actual Cluster elements
+		t.Run("CueClusterPositions", func(t *testing.T) {
+			for i, cp := range result.Segment.Cues.CuePoint {
+				if len(cp.CueTrackPositions) == 0 {
+					t.Errorf("CuePoint[%d] has no CueTrackPositions", i)
+					continue
+				}
+				clusterRelPos := cp.CueTrackPositions[0].CueClusterPosition
+				clusterAbsPos := segmentDataStart + int(clusterRelPos)
+
+				if clusterAbsPos+4 > len(data) {
+					t.Errorf("CuePoint[%d] Cluster position %d is beyond file size %d", i, clusterAbsPos, len(data))
+					continue
+				}
+				actualID := data[clusterAbsPos : clusterAbsPos+4]
+				if !bytes.Equal(actualID, clusterElementID) {
+					t.Errorf("CuePoint[%d] CueClusterPosition points to bytes %X, expected Cluster element ID %X",
+						i, actualID, clusterElementID)
+				}
+			}
+		})
+
+		// Find all Cluster positions by scanning binary and compare
+		t.Run("ClusterPositionCrossCheck", func(t *testing.T) {
+			var actualClusterPositions []int
+			for i := 0; i <= len(data)-4; i++ {
+				if bytes.Equal(data[i:i+4], clusterElementID) {
+					relPos := i - segmentDataStart
+					actualClusterPositions = append(actualClusterPositions, relPos)
+				}
+			}
+
+			// We should have 3 streaming clusters + 1 terminal cluster = 4 total
+			// and 3 CuePoints (one for each streaming cluster)
+			if len(result.Segment.Cues.CuePoint) != 3 {
+				t.Errorf("Expected 3 CuePoints, got %d", len(result.Segment.Cues.CuePoint))
+			}
+
+			// Verify each CueClusterPosition matches a real cluster
+			for i, cp := range result.Segment.Cues.CuePoint {
+				clusterPos := int(cp.CueTrackPositions[0].CueClusterPosition)
+				found := false
+				for _, actual := range actualClusterPositions {
+					if actual == clusterPos {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("CuePoint[%d] CueClusterPosition %d does not match any Cluster position. Actual positions: %v",
+						i, clusterPos, actualClusterPositions)
+				}
+			}
+		})
+	})
+
+	t.Run("WithEBMLHeader", func(t *testing.T) {
+		// Verify positions are correct when a full EBML header is present
+		// (matching real-world usage through the webm package)
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(&struct {
+				EBMLVersion        uint64 `ebml:"EBMLVersion"`
+				EBMLReadVersion    uint64 `ebml:"EBMLReadVersion"`
+				EBMLMaxIDLength    uint64 `ebml:"EBMLMaxIDLength"`
+				EBMLMaxSizeLength  uint64 `ebml:"EBMLMaxSizeLength"`
+				DocType            string `ebml:"EBMLDocType"`
+				DocTypeVersion     uint64 `ebml:"EBMLDocTypeVersion"`
+				DocTypeReadVersion uint64 `ebml:"EBMLDocTypeReadVersion"`
+			}{1, 1, 4, 8, "webm", 4, 2}),
+			WithSegmentInfo(&struct {
+				TimecodeScale uint64 `ebml:"TimecodeScale"`
+			}{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		for i := 0; i < 3; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+		ws[0].Close()
+		<-buf.Closed()
+
+		data := buf.Bytes()
+
+		// Find Segment data start
+		segmentID := []byte{0x18, 0x53, 0x80, 0x67}
+		segmentIdx := bytes.Index(data, segmentID)
+		if segmentIdx < 0 {
+			t.Fatal("Segment element not found")
+		}
+		segmentDataStart := segmentIdx + 4 + 8
+
+		// Verify SeekHead Cues position points to Cues element
+		cuesElementID := []byte{0x1C, 0x53, 0xBB, 0x6B}
+		clusterElementID := []byte{0x1F, 0x43, 0xB6, 0x75}
+
+		var result struct {
+			Header  interface{}     `ebml:"EBML"`
+			Segment cuesTestSegment `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(data), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+
+		if result.Segment.Cues == nil {
+			t.Fatal("Cues not found")
+		}
+
+		// Verify SeekHead Cues position
+		var seekHeadCuesPos uint64
+		for _, seek := range result.Segment.SeekHead.Seek {
+			if bytes.Equal(seek.SeekID, ebml.ElementCues.Bytes()) {
+				seekHeadCuesPos = seek.SeekPosition
+				break
+			}
+		}
+		cuesAbsPos := segmentDataStart + int(seekHeadCuesPos)
+		if cuesAbsPos+4 > len(data) || !bytes.Equal(data[cuesAbsPos:cuesAbsPos+4], cuesElementID) {
+			t.Errorf("SeekHead Cues position %d (abs %d) doesn't point to Cues element", seekHeadCuesPos, cuesAbsPos)
+		}
+
+		// Verify CueClusterPositions point to Cluster elements
+		for i, cp := range result.Segment.Cues.CuePoint {
+			clusterAbsPos := segmentDataStart + int(cp.CueTrackPositions[0].CueClusterPosition)
+			if clusterAbsPos+4 > len(data) || !bytes.Equal(data[clusterAbsPos:clusterAbsPos+4], clusterElementID) {
+				t.Errorf("CuePoint[%d] position %d (abs %d) doesn't point to Cluster",
+					i, cp.CueTrackPositions[0].CueClusterPosition, clusterAbsPos)
+			}
+		}
+	})
+}
+
+func TestWriteVoidElement(t *testing.T) {
+	for _, size := range []int{9, 100, 4096, 51200} {
+		var buf bytes.Buffer
+		if err := writeVoidElement(&buf, size); err != nil {
+			t.Fatalf("writeVoidElement(%d) failed: %v", size, err)
+		}
+		if buf.Len() != size {
+			t.Errorf("writeVoidElement(%d): got %d bytes, want %d", size, buf.Len(), size)
+		}
+		b := buf.Bytes()
+		if b[0] != 0xEC {
+			t.Errorf("writeVoidElement(%d): first byte = 0x%02X, want 0xEC", size, b[0])
+		}
+		if b[1] != 0x01 {
+			t.Errorf("writeVoidElement(%d): VINT marker = 0x%02X, want 0x01 (8-byte VINT)", size, b[1])
+		}
+	}
+}
+
+// durationInfo is a test segmentInfo that implements durationSettable.
+type durationInfo struct {
+	TimecodeScale uint64  `ebml:"TimecodeScale"`
+	Duration      float64 `ebml:"Duration,omitempty"`
+}
+
+func (i *durationInfo) SetDuration(d float64) { i.Duration = d }
+
+func TestBlockWriter_Duration(t *testing.T) {
+	t.Run("DurationWritten", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(&durationInfo{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		// Write blocks spanning multiple clusters.
+		// tc0=0, lastTc=3*0x8000=98304; expected Duration=98304.0
+		for i := 0; i < 4; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+		ws[0].Close()
+		<-buf.Closed()
+
+		data := buf.Bytes()
+
+		// Unmarshal and verify Duration via EBML
+		var result struct {
+			Segment struct {
+				Info struct {
+					Duration float64 `ebml:"Duration"`
+				} `ebml:"Info"`
+			} `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(data), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+		expected := float64(3 * 0x8000)
+		if result.Segment.Info.Duration != expected {
+			t.Errorf("Expected Duration %v, got %v", expected, result.Segment.Info.Duration)
+		}
+
+	})
+
+	t.Run("WithoutSettable", func(t *testing.T) {
+		// segmentInfo without SetDuration method — no Duration element should appear
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(&struct {
+				TimecodeScale uint64 `ebml:"TimecodeScale"`
+			}{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		for i := 0; i < 3; i++ {
+			if _, err := ws[0].Write(true, int64(i)*0x8000, []byte{0x01}); err != nil {
+				t.Fatalf("Failed to Write: '%v'", err)
+			}
+		}
+		ws[0].Close()
+		<-buf.Closed()
+
+		// Duration element with 8-byte VINT should not be present
+		durationWithVINT := []byte{0x44, 0x89, 0x88}
+		if bytes.Contains(buf.Bytes(), durationWithVINT) {
+			t.Error("Duration element should not be present when segmentInfo doesn't implement durationSettable")
+		}
+	})
+
+	t.Run("NoFrames", func(t *testing.T) {
+		buf := newSeekableBuffer()
+		ws, err := NewSimpleBlockWriter(
+			buf,
+			[]TrackDescription{{TrackNumber: 1}},
+			WithEBMLHeader(nil),
+			WithSegmentInfo(&durationInfo{TimecodeScale: 1000000}),
+			WithSeekHead(true),
+			WithCues(4096),
+		)
+		if err != nil {
+			t.Fatalf("Failed to create BlockWriter: '%v'", err)
+		}
+
+		// Close immediately without writing any frames
+		ws[0].Close()
+		<-buf.Closed()
+
+		data := buf.Bytes()
+		var result struct {
+			Segment struct {
+				Info struct {
+					Duration float64 `ebml:"Duration"`
+				} `ebml:"Info"`
+			} `ebml:"Segment,size=unknown"`
+		}
+		if err := ebml.Unmarshal(bytes.NewReader(data), &result); err != nil {
+			t.Fatalf("Failed to Unmarshal: '%v'", err)
+		}
+		if result.Segment.Info.Duration != 0.0 {
+			t.Errorf("Expected Duration 0.0 when no frames written, got %v", result.Segment.Info.Duration)
+		}
+	})
 }

--- a/mkvcore/option.go
+++ b/mkvcore/option.go
@@ -149,6 +149,7 @@ func WithBlockInterceptor(interceptor BlockInterceptor) BlockWriterOptionFn {
 // pre-allocated and likely inefficient index space.
 // reservedSize is the number of bytes (>=9) to reserve at the front of the file for Cues.
 // Requires WithSeekHead(true) and an io.WriteSeeker, not just io.WriteCloser.
+// If the index space is underallocated, Cues data is not written at all.
 func WithCues(reservedSize int) BlockWriterOptionFn {
 	return func(o *BlockWriterOptions) error {
 		if reservedSize < 9 {

--- a/mkvcore/option.go
+++ b/mkvcore/option.go
@@ -23,6 +23,21 @@ import (
 // ErrInvalidTrackNumber means that a track number is invalid. The track number must be larger than 0.
 var ErrInvalidTrackNumber = errors.New("invalid track number")
 
+// ErrCuesRequiresSeekHead means WithCues was used without WithSeekHead.
+var ErrCuesRequiresSeekHead = errors.New("WithCues requires WithSeekHead")
+
+// ErrCuesRequiresSeeker means WithCues was used with a writer that does not implement io.WriteSeeker.
+var ErrCuesRequiresSeeker = errors.New("WithCues requires an io.WriteSeeker")
+
+// ErrCuesReservedTooSmall means WithCues was called with a reservedSize smaller than 9 bytes.
+var ErrCuesReservedTooSmall = errors.New("WithCues reservedSize must be at least 9")
+
+// durationSettable is implemented by segment info types that support
+// having their Duration field set automatically (e.g. webm.Info).
+type durationSettable interface {
+	SetDuration(float64)
+}
+
 // BlockWriterOption configures a BlockWriterOptions.
 type BlockWriterOption interface {
 	ApplyToBlockWriterOptions(opts *BlockWriterOptions) error
@@ -86,6 +101,7 @@ type BlockWriterOptions struct {
 	interceptor         BlockInterceptor
 	mainTrackNumber     uint64
 	maxKeyframeInterval int64
+	cuesReservedSize    int
 }
 
 // WithEBMLHeader sets EBML header.
@@ -124,6 +140,21 @@ func WithMarshalOptions(opts ...ebml.MarshalOption) BlockWriterOptionFn {
 func WithBlockInterceptor(interceptor BlockInterceptor) BlockWriterOptionFn {
 	return func(o *BlockWriterOptions) error {
 		o.interceptor = interceptor
+		return nil
+	}
+}
+
+// WithCues enables writing a Cues (seek index) element and calculates Duration on finish.
+// This effectively allows writing seekable streams without additional remuxing, at the cost
+// pre-allocated and likely inefficient index space.
+// reservedSize is the number of bytes (>=9) to reserve at the front of the file for Cues.
+// Requires WithSeekHead(true) and an io.WriteSeeker, not just io.WriteCloser.
+func WithCues(reservedSize int) BlockWriterOptionFn {
+	return func(o *BlockWriterOptions) error {
+		if reservedSize < 9 {
+			return ErrCuesReservedTooSmall
+		}
+		o.cuesReservedSize = reservedSize
 		return nil
 	}
 }

--- a/mkvcore/seekhead.go
+++ b/mkvcore/seekhead.go
@@ -20,7 +20,7 @@ import (
 	"github.com/at-wat/ebml-go"
 )
 
-func setSeekHead(header *flexHeader, opts ...ebml.MarshalOption) error {
+func setSeekHead(header *flexHeader, withCues bool, opts ...ebml.MarshalOption) (segmentDataStart, durationElementPos uint64, err error) {
 	infoPos := new(uint64)
 	tracksPos := new(uint64)
 	header.Segment.SeekHead = &seekHeadFixed{}
@@ -34,6 +34,14 @@ func setSeekHead(header *flexHeader, opts ...ebml.MarshalOption) error {
 		SeekID:       ebml.ElementTracks.Bytes(),
 		SeekPosition: tracksPos,
 	})
+	var cuesPos *uint64
+	if withCues {
+		cuesPos = new(uint64)
+		header.Segment.SeekHead.Seek = append(header.Segment.SeekHead.Seek, seekFixed{
+			SeekID:       ebml.ElementCues.Bytes(),
+			SeekPosition: cuesPos,
+		})
+	}
 
 	var segmentPos uint64
 	hook := func(e *ebml.Element) {
@@ -54,8 +62,24 @@ func setSeekHead(header *flexHeader, opts ...ebml.MarshalOption) error {
 
 	var buf bytes.Buffer
 	if err := ebml.Marshal(header, &buf, optsWithHook...); err != nil {
-		return err
+		return 0, 0, err
 	}
 
-	return nil
+	// The Void (reserved for Cues) starts right after the header.
+	// Its position relative to segment data start is the SeekPosition for Cues.
+	if cuesPos != nil {
+		*cuesPos = uint64(buf.Len()) - segmentPos
+	}
+
+	// Find Duration element position by scanning the temporary buffer.
+	// We can't use the hook because child element positions don't account
+	// for the parent's VINT size (which is written after content for
+	// known-size elements). Byte scanning the buffer is exact.
+	// Duration element: ID 0x44 0x89, VINT 0x88 (8-byte float64).
+	durationPattern := []byte{0x44, 0x89, 0x88}
+	if idx := bytes.Index(buf.Bytes(), durationPattern); idx >= 0 {
+		durationElementPos = uint64(idx)
+	}
+
+	return segmentPos, durationElementPos, nil
 }

--- a/mkvcore/struct.go
+++ b/mkvcore/struct.go
@@ -30,6 +30,20 @@ type simpleBlockCluster struct {
 	BlockGroup  []simpleBlockGroup `ebml:"BlockGroup,omitempty"`
 }
 
+type cueTrackPosition struct {
+	CueTrack           uint64 `ebml:"CueTrack"`
+	CueClusterPosition uint64 `ebml:"CueClusterPosition"`
+}
+
+type cuePoint struct {
+	CueTime           uint64             `ebml:"CueTime"`
+	CueTrackPositions []cueTrackPosition `ebml:"CueTrackPositions"`
+}
+
+type cues struct {
+	CuePoint []cuePoint `ebml:"CuePoint"`
+}
+
 type seekFixed struct {
 	SeekID       []byte  `ebml:"SeekID"`
 	SeekPosition *uint64 `ebml:"SeekPosition,size=8"`

--- a/webm/webm.go
+++ b/webm/webm.go
@@ -54,6 +54,11 @@ type Info struct {
 	DateUTC       time.Time `ebml:"DateUTC,omitempty"`
 }
 
+// SetDuration sets the Duration field.
+// This implements the mkvcore durationSettable interface, allowing the
+// library to automatically write Duration when Cues are enabled.
+func (i *Info) SetDuration(d float64) { i.Duration = d }
+
 // TrackEntry represents TrackEntry element struct.
 type TrackEntry struct {
 	Name            string `ebml:"Name,omitempty"`


### PR DESCRIPTION
This somewhat hacky implementation mirrors ffmpegs `cues_to_front` + `reserve_index_space`. It allows a stream to be recorded without upfront size information, keeping track of cues and total duration in memory. When the writer is finished, it updates the header with cues and duration metadata.

This effectively makes the resulting file seekable out of the box, with no specific `SeekHead` configuration upfront.

Keep in mind:
- This only works with an underlying io.WriteSeeker
- The index space needs to be reserved and will likely not be used very efficiently
- This implementation does not mirror ffmpegs behaviour of shifting the whole file if the index space is underallocated. Instead, cues data is not written at all.

Hacky implementation decisions I would be very happy to change, if there are better ideas:
- `durationSettable` interface is introduced to `mkvcore` and implemented by `webm.Info` to avoid circular dependencies. This is needed to allow us to modify the duration header and prevent it from being completely skipped, as it's `json:omitempty`. Maybe there is a cleaner way? Alternatively, a user could be expected to provide non-zero duration upfront if using this option.
- Finding the duration element position in `mkvcore/seekhead.go` by searching the buffer.

This isn't the prettiest piece of code, but it does get the job done and may be useful to some, judging by the few existing issues around cues.