### PR TITLE
Fix cue list to point key frames not only clusters

### DIFF
--- a/mkvcore/blockwriter.go
+++ b/mkvcore/blockwriter.go
@@ -83,13 +83,6 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 		interceptor: nil,
 		seekHead:    false,
 	}
-	if options.cuesReservedSize > 0 {
-		// Defaults to refer the first track number for collecting cues
-		for _, t := range tracks {
-			options.mainTrackNumber = t.TrackNumber
-			break
-		}
-	}
 	for _, o := range opts {
 		if err := o.ApplyToBlockWriterOptions(options); err != nil {
 			return nil, err
@@ -106,6 +99,11 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 		seeker, ok = w0.(io.WriteSeeker)
 		if !ok {
 			return nil, ErrCuesRequiresSeeker
+		}
+		// Defaults to refer the first track number for collecting cues
+		for _, t := range tracks {
+			options.mainTrackNumber = t.TrackNumber
+			break
 		}
 	}
 

--- a/mkvcore/blockwriter.go
+++ b/mkvcore/blockwriter.go
@@ -78,10 +78,11 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 				panic(err)
 			},
 		},
-		ebmlHeader:  nil,
-		segmentInfo: nil,
-		interceptor: nil,
-		seekHead:    false,
+		ebmlHeader:      nil,
+		segmentInfo:     nil,
+		interceptor:     nil,
+		seekHead:        false,
+		mainTrackNumber: 1,
 	}
 	for _, o := range opts {
 		if err := o.ApplyToBlockWriterOptions(options); err != nil {
@@ -203,8 +204,9 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 		lastTc := int64(0)
 
 		// Cues tracking state
-		runningPos := posAfterHeader
+		clusterPos := posAfterHeader
 		var cuePoints []cuePoint
+		var blockIndex uint64
 
 		defer func() {
 			// Finalize WebM
@@ -275,18 +277,8 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 					// Create new Cluster
 					tc1 = f.timestamp
 					tc = 0
-
-					// Collect CuePoint before Clear
-					if options.cuesReservedSize > 0 {
-						runningPos += uint64(w.Size())
-						cuePoints = append(cuePoints, cuePoint{
-							CueTime: uint64(tc1 - tc0),
-							CueTrackPositions: []cueTrackPosition{{
-								CueTrack:           f.trackNumber,
-								CueClusterPosition: runningPos - segmentDataStart,
-							}},
-						})
-					}
+					clusterPos += uint64(w.Size())
+					blockIndex = 0
 
 					cluster := struct {
 						Cluster simpleBlockCluster `ebml:"Cluster,size=unknown"`
@@ -310,6 +302,20 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 						options.onError(ErrIgnoreOldFrame)
 					}
 					continue
+				}
+
+				blockIndex++
+
+				// Collect CuePoint
+				if options.cuesReservedSize > 0 && f.trackNumber == options.mainTrackNumber && f.keyframe {
+					cuePoints = append(cuePoints, cuePoint{
+						CueTime: uint64(tc1 - tc0 + tc),
+						CueTrackPositions: []cueTrackPosition{{
+							CueTrack:           f.trackNumber,
+							CueClusterPosition: clusterPos - segmentDataStart,
+							CueBlockNumber:     blockIndex,
+						}},
+					})
 				}
 
 				b := struct {

--- a/mkvcore/blockwriter.go
+++ b/mkvcore/blockwriter.go
@@ -101,9 +101,11 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 			return nil, ErrCuesRequiresSeeker
 		}
 		// Defaults to refer the first track number for collecting cues
-		for _, t := range tracks {
-			options.mainTrackNumber = t.TrackNumber
-			break
+		if options.mainTrackNumber == 0 {
+			for _, t := range tracks {
+				options.mainTrackNumber = t.TrackNumber
+				break
+			}
 		}
 	}
 

--- a/mkvcore/blockwriter.go
+++ b/mkvcore/blockwriter.go
@@ -78,11 +78,17 @@ func NewSimpleBlockWriter(w0 io.WriteCloser, tracks []TrackDescription, opts ...
 				panic(err)
 			},
 		},
-		ebmlHeader:      nil,
-		segmentInfo:     nil,
-		interceptor:     nil,
-		seekHead:        false,
-		mainTrackNumber: 1,
+		ebmlHeader:  nil,
+		segmentInfo: nil,
+		interceptor: nil,
+		seekHead:    false,
+	}
+	if options.cuesReservedSize > 0 {
+		// Defaults to refer the first track number for collecting cues
+		for _, t := range tracks {
+			options.mainTrackNumber = t.TrackNumber
+			break
+		}
 	}
 	for _, o := range opts {
 		if err := o.ApplyToBlockWriterOptions(options); err != nil {

--- a/mkvcore/blockwriter_test.go
+++ b/mkvcore/blockwriter_test.go
@@ -899,7 +899,6 @@ func TestBlockWriter_WithCues(t *testing.T) {
 				if !bytes.Equal(actualID, clusterElementID) {
 					t.Errorf("CuePoint[%d] CueClusterPosition points to bytes %X, expected Cluster element ID %X",
 						i, actualID, clusterElementID)
-					continue
 				}
 			}
 		})

--- a/mkvcore/blockwriter_test.go
+++ b/mkvcore/blockwriter_test.go
@@ -647,6 +647,7 @@ type cuesTestSegment struct {
 			CueTrackPositions []struct {
 				CueTrack           uint64 `ebml:"CueTrack"`
 				CueClusterPosition uint64 `ebml:"CueClusterPosition"`
+				CueBlockNumber     uint64 `ebml:"CueBlockNumber"`
 			} `ebml:"CueTrackPositions"`
 		} `ebml:"CuePoint"`
 	} `ebml:"Cues"`
@@ -898,12 +899,13 @@ func TestBlockWriter_WithCues(t *testing.T) {
 				if !bytes.Equal(actualID, clusterElementID) {
 					t.Errorf("CuePoint[%d] CueClusterPosition points to bytes %X, expected Cluster element ID %X",
 						i, actualID, clusterElementID)
+					continue
 				}
 			}
 		})
 
 		// Find all Cluster positions by scanning binary and compare
-		t.Run("ClusterPositionCrossCheck", func(t *testing.T) {
+		t.Run("ClusterPositionAndBlockNumberCrossCheck", func(t *testing.T) {
 			var actualClusterPositions []int
 			for i := 0; i <= len(data)-4; i++ {
 				if bytes.Equal(data[i:i+4], clusterElementID) {
@@ -919,18 +921,36 @@ func TestBlockWriter_WithCues(t *testing.T) {
 			}
 
 			// Verify each CueClusterPosition matches a real cluster
+			// and the cluster has matching block
 			for i, cp := range result.Segment.Cues.CuePoint {
 				clusterPos := int(cp.CueTrackPositions[0].CueClusterPosition)
 				found := false
-				for _, actual := range actualClusterPositions {
+				var iCluster int
+				for i, actual := range actualClusterPositions {
 					if actual == clusterPos {
 						found = true
+						iCluster = i
 						break
 					}
 				}
 				if !found {
 					t.Errorf("CuePoint[%d] CueClusterPosition %d does not match any Cluster position. Actual positions: %v",
 						i, clusterPos, actualClusterPositions)
+					continue
+				}
+
+				blockNumber := cp.CueTrackPositions[0].CueBlockNumber
+
+				if blockNumber == 0 {
+					t.Errorf("CuePoint[%d] CueBlockNumber must not be 0. Actual: %d", i, blockNumber)
+					continue
+				}
+				if n := len(result.Segment.Cluster[iCluster].SimpleBlock) + 1; blockNumber >= uint64(n) {
+					t.Errorf("CuePoint[%d] CueBlockNumber out-of-boundary. Actual: %d, max: %d", i, blockNumber, n+1)
+					continue
+				}
+				if !result.Segment.Cluster[iCluster].SimpleBlock[blockNumber-1].Keyframe {
+					t.Errorf("CuePoint[%d] CueBlockNumber must point keyframe", i)
 				}
 			}
 		})

--- a/mkvcore/struct.go
+++ b/mkvcore/struct.go
@@ -33,6 +33,7 @@ type simpleBlockCluster struct {
 type cueTrackPosition struct {
 	CueTrack           uint64 `ebml:"CueTrack"`
 	CueClusterPosition uint64 `ebml:"CueClusterPosition"`
+	CueBlockNumber     uint64 `ebml:"CueBlockNumber"`
 }
 
 type cuePoint struct {


### PR DESCRIPTION
Fix CuePoints collection based on the Matroska's document.
https://www.matroska.org/technical/cues.html

Currently, CuePoints only refer head of the clusters.
However, the recommendation says each keyframe should be referenced by CuePoint.