### PR TITLE
Limit master element nesting depth to prevent stack overflow

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -36,6 +36,18 @@ var ErrInvalidElementSize = errors.New("invalid element size")
 // ErrReadStopped is returned if unmarshaler finished to read element which has stop tag.
 var ErrReadStopped = errors.New("read stopped")
 
+// ErrElementTooDeep means that the master element nesting depth exceeded the
+// maximum accepted by Unmarshal. It guards against unbounded recursion (and the
+// resulting stack exhaustion) when decoding deeply nested untrusted input.
+var ErrElementTooDeep = errors.New("element nesting too deep")
+
+// maxElementDepth is the maximum master element nesting depth accepted by
+// Unmarshal. Real-world EBML/Matroska files nest only a handful of levels, so
+// this bound is far above any legitimate document while preventing a crafted
+// stream of nested master elements from recursing until the goroutine stack
+// overflows.
+const maxElementDepth = 1024
+
 // Unmarshal EBML stream.
 func Unmarshal(r io.Reader, val interface{}, opts ...UnmarshalOption) error {
 	options := &UnmarshalOptions{}
@@ -67,6 +79,9 @@ func Unmarshal(r io.Reader, val interface{}, opts ...UnmarshalOption) error {
 }
 
 func (vd *valueDecoder) readElement(r0 io.Reader, n int64, vo reflect.Value, depth int, pos uint64, parent *Element, options *UnmarshalOptions) (io.Reader, error) {
+	if depth > maxElementDepth {
+		return nil, wrapErrorf(ErrElementTooDeep, "unmarshalling nested element at depth %d", depth)
+	}
 	pos0 := pos
 	var r rollbackReader
 	if options.ignoreUnknown {

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -752,3 +752,20 @@ func BenchmarkUnmarshal(b *testing.B) {
 		}
 	}
 }
+
+func TestUnmarshal_DeeplyNestedMaster(t *testing.T) {
+	// A stream consisting only of nested master elements (ChapterAtom, 0xB6,
+	// with unknown data size 0xFF) must not recurse without bound. Without a
+	// depth limit this exhausts the goroutine stack and crashes the process
+	// with a fatal "stack overflow" for a small (a few MB) untrusted input.
+	var buf bytes.Buffer
+	for i := 0; i < maxElementDepth*4; i++ {
+		buf.Write([]byte{0xB6, 0xFF})
+	}
+
+	var out struct{}
+	err := Unmarshal(bytes.NewReader(buf.Bytes()), &out)
+	if !errors.Is(err, ErrElementTooDeep) {
+		t.Fatalf("expected ErrElementTooDeep, got %v", err)
+	}
+}


### PR DESCRIPTION
### Problem

`Unmarshal` recurses once per nested master element (`readElement` calls itself for every `DataTypeMaster` child), and there is no bound on how deep that recursion can go. Because element IDs are looked up in a flat table regardless of parent context, and master elements may use the unknown-size marker, a stream that is just nested master elements decodes into arbitrarily deep recursion.

A few megabytes of a repeated 2-byte pattern is enough to exhaust the goroutine stack and terminate the whole process with an uncatchable `fatal error: stack overflow`. This is reachable directly from the main `Unmarshal` entry point on untrusted input, so any application decoding a file/stream from an untrusted source can be crashed.

Minimal reproducer (ChapterAtom `0xB6` + the `0xFF` unknown-size marker, repeated):

```go
var buf bytes.Buffer
for i := 0; i < 2_000_000; i++ {
    buf.Write([]byte{0xB6, 0xFF})
}
var out struct{}
err := ebml.Unmarshal(bytes.NewReader(buf.Bytes()), &out) // fatal error: stack overflow
```

### Fix

Cap the accepted master-element nesting depth and return a new `ErrElementTooDeep` once it is exceeded, instead of recursing until the stack is exhausted. The limit (1024) is far above any real EBML/Matroska document — legitimate files nest only a handful of levels — so valid input is unaffected. The existing test suite (including the WebM/Matroska round-trip and official-test cases) still passes.

Added a regression test that feeds a deeply nested stream and asserts a clean `ErrElementTooDeep` is returned rather than the process crashing.